### PR TITLE
Increasing timeout to elasticsearch to be up

### DIFF
--- a/Azkfile.js
+++ b/Azkfile.js
@@ -109,6 +109,7 @@ systems({
     ports: {
       http: "9200",
     },
+    wait: {"retry": 20, "timeout": 1000},
     export_envs : {
       ELASTICSEARCH_URL: "#{system.name}.#{azk.default_domain}:#{net.port[9200]}",
     },


### PR DESCRIPTION
Sometimes, starting `azk` fails due to `elasticsearch` timeout. Giving it a little more time to be up should do the trick and avoid this issue.